### PR TITLE
Add in "data-layout" field to target specification

### DIFF
--- a/thumbv7em-none-eabi.json
+++ b/thumbv7em-none-eabi.json
@@ -1,6 +1,7 @@
 {
     "arch": "arm",
     "cpu": "cortex-m4",
+    "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
     "disable-redzone": true,
     "executables": true,
     "llvm-target": "thumbv7em-none-eabi",


### PR DESCRIPTION
- Fixes build for current rust nightly

I tried building this example but rust yelled at me for not having the data-layout specified for the architecture.  After adding in the appropriate field, the instructions in README.md appear to work as expected.
